### PR TITLE
Android security 11.0.0 release 66

### DIFF
--- a/src/nfc/nci/nci_hmsgs.cc
+++ b/src/nfc/nci/nci_hmsgs.cc
@@ -630,6 +630,10 @@ uint8_t nci_snd_set_routing_cmd(bool more, uint8_t num_tlv, uint8_t tlv_size,
   uint8_t* pp;
   uint8_t size = tlv_size + 2;
 
+  if (size < tlv_size) {
+    return (NCI_STATUS_FAILED);
+  }
+
   if (tlv_size == 0) {
     /* just to terminate routing table
      * 2 bytes (more=FALSE and num routing entries=0) */


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r66' of https://android.googlesource.com/platform/system/nfc into arrow-11.0

Android security 11.0.0 release 66
Tag: https://android.googlesource.com/platform/system/nfc/+/refs/tags/android-security-11.0.0_r66

Merge cherrypicks of ['googleplex-android-review.googlesource.com/21162699'] into security-aosp-rvc-release.

Change-Id: [Ie50462c325f5a468451c85ec0ad5ceff855aa8c8](https://android-review.googlesource.com/#/q/Ie50462c325f5a468451c85ec0ad5ceff855aa8c8)