### PR TITLE
Android security 11.0.0 release 69

### DIFF
--- a/src/nfc/tags/rw_i93.cc
+++ b/src/nfc/tags/rw_i93.cc
@@ -578,6 +578,15 @@ void rw_i93_send_to_upper(NFC_HDR* p_resp) {
     case I93_CMD_GET_MULTI_BLK_SEC:
     case I93_CMD_EXT_GET_MULTI_BLK_SEC:
 
+      if (UINT16_MAX - length < NFC_HDR_SIZE) {
+        rw_data.i93_cmd_cmpl.status = NFC_STATUS_FAILED;
+        rw_data.i93_cmd_cmpl.command = p_i93->sent_cmd;
+        rw_cb.tcb.i93.sent_cmd = 0;
+
+        event = RW_I93_CMD_CMPL_EVT;
+        break;
+      }
+
       /* forward tag data or security status */
       p_buff = (NFC_HDR*)GKI_getbuf((uint16_t)(length + NFC_HDR_SIZE));
 


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r69' of https://android.googlesource.com/platform/system/nfc into arrow-11.0

Android security 11.0.0 release 69
Tag: https://android.googlesource.com/platform/system/nfc/+/refs/tags/android-security-11.0.0_r69

Merge cherrypicks of ['googleplex-android-review.googlesource.com/22977056'] into security-aosp-rvc-release.

Change-Id: [Ib2224f4869ff46281f12fe37bcb8e320f9613efa](https://android-review.googlesource.com/#/q/Ib2224f4869ff46281f12fe37bcb8e320f9613efa)